### PR TITLE
added place to add scrips

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,13 +4,11 @@ services:
     image: "neo4j:latest"
     ports:
       - "7687:7687"
-      - "7473:7473"
       - "7474:7474"
     volumes:
-      - "$HOME/neo4j/data:/data neo4j"
-      - "$HOME/neo4j/data:/data"
-      - "$HOME/neo4j/logs:/logs"
-      - "$HOME/neo4j/import:/var/lib/neo4j/import"
-      - "$HOME/neo4j/plugins:/plugins"
+      - neo4j_data:/data
+      - ./scripts/lib/import:/var/lib/neo4j/import
     environment:
       - NEO4J_AUTH=neo4j/development
+volumes:
+  neo4j_data:

--- a/scripts/.eslintignore
+++ b/scripts/.eslintignore
@@ -1,1 +1,2 @@
 build/
+./lib/

--- a/scripts/lib/import/load.csv
+++ b/scripts/lib/import/load.csv
@@ -1,0 +1,5 @@
+Id,Name,Year
+1,ABBA,1992
+2,Roxette,1986
+3,Europe,1979
+4,The Cardigans,1992


### PR DESCRIPTION
To use load csv file, add them in `scripts/lib/import` directory.

Example:

`scripts/lib/import/load.csv`
```
Id,Name,Year
1,ABBA,1992
2,Roxette,1986
3,Europe,1979
4,The Cardigans,1992
```

New files here will automatically be accessible within docker container, meaning they're importable. The following line in `docker-compose.yml` does this.
```
- ./scripts/lib/import:/var/lib/neo4j/import
```

To import the csv file, run 
```
docker exec -it [container_name] cypher-shell -u neo4j -p development
LOAD CSV WITH HEADERS FROM 'file:///load.csv' AS line
CREATE (:Artist {name: line.Name, year: toInteger(line.Year)})
```

![image](https://user-images.githubusercontent.com/65472533/196117491-95a326b2-6670-44a8-a5fe-13a71d23a54d.png)

### Important
After running the script, you'll have to add read/write/execute permissions back into the import directory. Not sure why it gets revoked but I had to do it on my end.
```
sudo chmod a+rwx [file]
```

Additional documentation: https://neo4j.com/docs/cypher-manual/current/clauses/load-csv/

